### PR TITLE
FE Feature: Implement FlowEditing Page with FlowAPI & Facebook API Integration

### DIFF
--- a/client/src/app/pages/customflow/page.tsx
+++ b/client/src/app/pages/customflow/page.tsx
@@ -1,12 +1,16 @@
 "use client";
 import * as React from "react";
+import { useSearchParams } from "next/navigation";
 import FlowEditor from "@/components/flow/FlowEditor";
 
 export default function Page() {
+	const searchParams = useSearchParams();
+	const flowId = searchParams.get("id");
+
 	return (
 		<>
 			<div className="fp-wrapper w-full h-screen overflow-hidden">
-				<FlowEditor />
+				<FlowEditor flowId={flowId} />
 			</div>
 		</>
 	);

--- a/client/src/app/pages/flow/page.tsx
+++ b/client/src/app/pages/flow/page.tsx
@@ -27,6 +27,7 @@ import {
 	enableFlow,
 	disableFlow,
 	deleteFlow,
+	getFlowById,
 } from "@/services/flowServices";
 
 const UploadBox = styled(Paper)(({ theme }) => ({
@@ -118,8 +119,8 @@ const FlowList: React.FC<FlowListProps> = ({
 
 	const handleEditFlow = (flow: Flow) => {
 		console.log(`Editing flow: ${flow.name}`);
-		// Điều hướng đến trang chỉnh sửa luồng, ví dụ:
-		// history.push(`/edit-flow/${flow.id}`);
+		// Chuyển hướng đến trang chỉnh sửa luồng với ID flow
+		window.location.href = `/pages/customflow?id=${flow.id}`;
 	};
 
 	return (
@@ -135,7 +136,6 @@ const FlowList: React.FC<FlowListProps> = ({
 							transition: "background-color 0.3s",
 						}}
 						className="scenario flow-item"
-						onClick={() => handleEditFlow(flow)}
 					>
 						<Grid container alignItems="center">
 							<Grid item xs={2}>
@@ -158,23 +158,21 @@ const FlowList: React.FC<FlowListProps> = ({
 								</Box>
 							</Grid>
 							<Grid item xs={8}>
-								<Link href="/pages/customflow">
-									<Box>
-										<Typography variant="h6">{flow.name}</Typography>
-										<Typography
-											variant="body2"
-											color="textSecondary"
-											style={{ display: "flex", alignItems: "center" }}
-										>
-											<CalendarMonthIcon style={{ marginRight: "5px" }} />
-											{flow.date}
-											<PersonIcon
-												style={{ marginRight: "5px", marginLeft: "10px" }}
-											/>
-											{flow.creator}
-										</Typography>
-									</Box>
-								</Link>
+								<Box onClick={() => handleEditFlow(flow)}>
+									<Typography variant="h6">{flow.name}</Typography>
+									<Typography
+										variant="body2"
+										color="textSecondary"
+										style={{ display: "flex", alignItems: "center" }}
+									>
+										<CalendarMonthIcon style={{ marginRight: "5px" }} />
+										{flow.date}
+										<PersonIcon
+											style={{ marginRight: "5px", marginLeft: "10px" }}
+										/>
+										{flow.creator}
+									</Typography>
+								</Box>
 							</Grid>
 							<Grid item xs={1}>
 								<Tooltip
@@ -281,7 +279,6 @@ const FlowList: React.FC<FlowListProps> = ({
 };
 
 const ImportLeadUI: React.FC = () => {
-	const [open, setOpen] = useState<boolean>(false);
 	const [flows, setFlows] = useState<Flow[]>([]);
 	const [activeFlowId, setActiveFlowId] = useState<string | null>(null);
 	const [isLoading, setIsLoading] = useState<boolean>(false);
@@ -345,14 +342,6 @@ const ImportLeadUI: React.FC = () => {
 		}
 	};
 
-	const handleClickOpen = () => {
-		setOpen(true);
-	};
-
-	const handleClose = () => {
-		setOpen(false);
-	};
-
 	return (
 		<Box
 			style={{ minHeight: "80vh", display: "flex", flexDirection: "column" }}
@@ -366,16 +355,14 @@ const ImportLeadUI: React.FC = () => {
 				}}
 			>
 				<h1>All scenarios</h1>
-				<Button variant="outlined" onClick={handleClickOpen}>
+				<Button variant="outlined" component={Link} href="/pages/customflow">
 					<AddIcon
 						sx={{
 							position: "relative",
 							paddingRight: "5px",
 						}}
-					/>{" "}
-					<Link href="/pages/customflow">
-						<Typography color="primary">Create a new Scenario</Typography>
-					</Link>
+					/>
+					<Typography color="primary">Create a new Scenario</Typography>
 				</Button>
 			</Box>
 			{isLoading ? (

--- a/client/src/app/pages/leadpipeline/Importlead.tsx
+++ b/client/src/app/pages/leadpipeline/Importlead.tsx
@@ -120,7 +120,7 @@ const ImportLeadUI = () => {
 								<MenuItem value="append">Append</MenuItem>
 								<MenuItem value="overwrite">Overwrite</MenuItem>
 							</Select>
-							<Box display="flex" alignItems="center" mt={2}>
+							<Box display="flex" alignItems="center" mt={2} gap={1}>
 								<Typography variant="body2">Enable Notifications</Typography>
 								<Switch />
 							</Box>

--- a/client/src/components/facebook/PageWebhookList.tsx
+++ b/client/src/components/facebook/PageWebhookList.tsx
@@ -1,0 +1,193 @@
+import React, { useState, useEffect } from "react";
+import {
+	Box,
+	Typography,
+	Paper,
+	List,
+	ListItem,
+	ListItemText,
+	ListItemSecondaryAction,
+	Divider,
+	Button,
+	CircularProgress,
+	Alert,
+	IconButton,
+	Collapse,
+	Tab,
+	Tabs,
+} from "@mui/material";
+import {
+	ExpandMore,
+	ExpandLess,
+	Refresh as RefreshIcon,
+} from "@mui/icons-material";
+import {
+	useFacebookConnections,
+	useFacebookPages,
+} from "@/services/facebookServices";
+import WebhookManager from "./WebhookManager";
+
+interface PageWebhookListProps {
+	title?: string;
+}
+
+const PageWebhookList: React.FC<PageWebhookListProps> = ({
+	title = "Facebook Page Webhook Management",
+}) => {
+	const {
+		connections,
+		loading: loadingConnections,
+		error: connectionsError,
+	} = useFacebookConnections();
+	const [selectedConnection, setSelectedConnection] = useState<string | null>(
+		null
+	);
+	const [expandedPage, setExpandedPage] = useState<string | null>(null);
+	const [refreshTrigger, setRefreshTrigger] = useState<number>(0);
+
+	const {
+		pages,
+		loading: loadingPages,
+		error: pagesError,
+	} = useFacebookPages(selectedConnection);
+
+	// Auto-select the first connection when loaded
+	useEffect(() => {
+		if (connections.length > 0 && !selectedConnection) {
+			setSelectedConnection(connections[0].profile.id);
+		}
+	}, [connections, selectedConnection]);
+
+	const handleRefresh = () => {
+		setRefreshTrigger((prev) => prev + 1);
+	};
+
+	const handleTabChange = (_: React.SyntheticEvent, newValue: string) => {
+		setSelectedConnection(newValue);
+		setExpandedPage(null);
+	};
+
+	const handleTogglePage = (pageId: string) => {
+		setExpandedPage(expandedPage === pageId ? null : pageId);
+	};
+
+	return (
+		<Paper elevation={3} sx={{ p: 3, mb: 4 }}>
+			<Box
+				sx={{
+					display: "flex",
+					justifyContent: "space-between",
+					alignItems: "center",
+					mb: 2,
+				}}
+			>
+				<Typography variant="h5" component="h2">
+					{title}
+				</Typography>
+
+				<Button
+					startIcon={<RefreshIcon />}
+					onClick={handleRefresh}
+					disabled={loadingConnections || loadingPages}
+				>
+					Refresh
+				</Button>
+			</Box>
+
+			{(connectionsError || pagesError) && (
+				<Alert severity="error" sx={{ mb: 3 }}>
+					{connectionsError || pagesError}
+				</Alert>
+			)}
+
+			{loadingConnections ? (
+				<Box sx={{ display: "flex", justifyContent: "center", p: 4 }}>
+					<CircularProgress />
+				</Box>
+			) : connections.length === 0 ? (
+				<Alert severity="info">
+					No Facebook connections found. Please connect your Facebook account
+					first.
+				</Alert>
+			) : (
+				<>
+					{/* Connection Tabs */}
+					<Tabs
+						value={selectedConnection || ""}
+						onChange={handleTabChange}
+						variant="scrollable"
+						scrollButtons="auto"
+						sx={{ mb: 3 }}
+					>
+						{connections.map((connection) => (
+							<Tab
+								key={connection.profile.id}
+								value={connection.profile.id}
+								label={connection.profile.name}
+							/>
+						))}
+					</Tabs>
+
+					{/* Pages List */}
+					{loadingPages ? (
+						<Box sx={{ display: "flex", justifyContent: "center", p: 4 }}>
+							<CircularProgress />
+						</Box>
+					) : pages.length === 0 ? (
+						<Alert severity="info">
+							No Facebook pages found for this connection.
+						</Alert>
+					) : (
+						<List>
+							{pages.map((page) => (
+								<React.Fragment key={page.id}>
+									<ListItem sx={{ cursor: "pointer" }}>
+										<ListItemText
+											primary={page.name}
+											secondary={`Page ID: ${page.id}`}
+											onClick={() => handleTogglePage(page.id)}
+										/>
+										<ListItemSecondaryAction>
+											<IconButton
+												edge="end"
+												onClick={(e) => {
+													e.stopPropagation();
+													handleTogglePage(page.id);
+												}}
+											>
+												{expandedPage === page.id ? (
+													<ExpandLess />
+												) : (
+													<ExpandMore />
+												)}
+											</IconButton>
+										</ListItemSecondaryAction>
+									</ListItem>
+
+									<Collapse
+										in={expandedPage === page.id}
+										timeout="auto"
+										unmountOnExit
+									>
+										<Box sx={{ pl: 4, pr: 4, pb: 3 }}>
+											<WebhookManager
+												pageId={page.id}
+												pageName={page.name}
+												isSubscribed={page.subscribed || false}
+												onUpdate={handleRefresh}
+											/>
+										</Box>
+									</Collapse>
+
+									<Divider component="li" />
+								</React.Fragment>
+							))}
+						</List>
+					)}
+				</>
+			)}
+		</Paper>
+	);
+};
+
+export default PageWebhookList;

--- a/client/src/components/facebook/WebhookManager.tsx
+++ b/client/src/components/facebook/WebhookManager.tsx
@@ -1,0 +1,201 @@
+import React, { useState } from "react";
+import {
+	Box,
+	Button,
+	Typography,
+	Paper,
+	Alert,
+	CircularProgress,
+	Divider,
+	Switch,
+	FormControlLabel,
+	Dialog,
+	DialogActions,
+	DialogContent,
+	DialogContentText,
+	DialogTitle,
+	TextField,
+} from "@mui/material";
+import {
+	subscribePageToWebhook,
+	unsubscribePageFromWebhook,
+} from "@/services/facebookServices";
+
+interface WebhookManagerProps {
+	pageId: string;
+	pageName: string;
+	isSubscribed?: boolean;
+	onUpdate?: () => void;
+}
+
+const WebhookManager: React.FC<WebhookManagerProps> = ({
+	pageId,
+	pageName,
+	isSubscribed = false,
+	onUpdate,
+}) => {
+	const [loading, setLoading] = useState<boolean>(false);
+	const [error, setError] = useState<string | null>(null);
+	const [success, setSuccess] = useState<string | null>(null);
+	const [subscriptionStatus, setSubscriptionStatus] =
+		useState<boolean>(isSubscribed);
+	const [openUnsubscribeDialog, setOpenUnsubscribeDialog] =
+		useState<boolean>(false);
+	const [appId, setAppId] = useState<string>("");
+
+	const handleSubscribe = async () => {
+		try {
+			setLoading(true);
+			setError(null);
+			setSuccess(null);
+
+			const response = await subscribePageToWebhook(pageId);
+
+			if (response && !response.error) {
+				setSubscriptionStatus(true);
+				setSuccess(`Successfully subscribed "${pageName}" to webhook`);
+				if (onUpdate) onUpdate();
+			} else {
+				setError(response.error?.message || "Failed to subscribe to webhook");
+			}
+		} catch (err: any) {
+			setError(err.message || "An unexpected error occurred");
+		} finally {
+			setLoading(false);
+		}
+	};
+
+	const handleUnsubscribe = async () => {
+		if (!appId.trim()) {
+			setError("App ID is required for unsubscribing");
+			return;
+		}
+
+		try {
+			setLoading(true);
+			setError(null);
+			setSuccess(null);
+
+			const response = await unsubscribePageFromWebhook(pageId, appId);
+
+			if (response && !response.error) {
+				setSubscriptionStatus(false);
+				setSuccess(`Successfully unsubscribed "${pageName}" from webhook`);
+				setOpenUnsubscribeDialog(false);
+				if (onUpdate) onUpdate();
+			} else {
+				setError(
+					response.error?.message || "Failed to unsubscribe from webhook"
+				);
+			}
+		} catch (err: any) {
+			setError(err.message || "An unexpected error occurred");
+		} finally {
+			setLoading(false);
+		}
+	};
+
+	return (
+		<Paper elevation={2} sx={{ p: 3, mb: 3 }}>
+			<Typography variant="h6" gutterBottom>
+				Facebook Page Webhook Manager
+			</Typography>
+
+			<Divider sx={{ my: 2 }} />
+
+			<Box sx={{ mb: 2 }}>
+				<Typography variant="subtitle1">Page: {pageName}</Typography>
+				<Typography variant="body2" color="text.secondary">
+					ID: {pageId}
+				</Typography>
+			</Box>
+
+			<Box sx={{ display: "flex", alignItems: "center", mb: 2 }}>
+				<FormControlLabel
+					control={
+						<Switch
+							checked={subscriptionStatus}
+							onChange={(e) => {
+								if (!e.target.checked) {
+									setOpenUnsubscribeDialog(true);
+								} else {
+									handleSubscribe();
+								}
+							}}
+							disabled={loading}
+						/>
+					}
+					label={
+						subscriptionStatus ? "Subscribed to webhook" : "Not subscribed"
+					}
+				/>
+
+				{loading && <CircularProgress size={24} sx={{ ml: 2 }} />}
+			</Box>
+
+			{error && (
+				<Alert severity="error" sx={{ mb: 2 }}>
+					{error}
+				</Alert>
+			)}
+
+			{success && (
+				<Alert severity="success" sx={{ mb: 2 }}>
+					{success}
+				</Alert>
+			)}
+
+			<Box sx={{ mt: 3 }}>
+				<Typography variant="body2" color="text.secondary">
+					When subscribed, your Facebook page will send lead data to your
+					application whenever a new lead is generated.
+				</Typography>
+			</Box>
+
+			{/* Unsubscribe Dialog */}
+			<Dialog
+				open={openUnsubscribeDialog}
+				onClose={() => setOpenUnsubscribeDialog(false)}
+			>
+				<DialogTitle>Unsubscribe from Webhook</DialogTitle>
+				<DialogContent>
+					<DialogContentText>
+						To unsubscribe this page from the webhook, please enter the Facebook
+						App ID. This is required by Facebook to complete the unsubscription
+						process.
+					</DialogContentText>
+					<TextField
+						autoFocus
+						margin="dense"
+						id="appId"
+						label="Facebook App ID"
+						type="text"
+						fullWidth
+						variant="outlined"
+						value={appId}
+						onChange={(e) => setAppId(e.target.value)}
+						sx={{ mt: 2 }}
+					/>
+				</DialogContent>
+				<DialogActions>
+					<Button
+						onClick={() => setOpenUnsubscribeDialog(false)}
+						color="primary"
+					>
+						Cancel
+					</Button>
+					<Button
+						onClick={handleUnsubscribe}
+						color="primary"
+						variant="contained"
+						disabled={!appId.trim() || loading}
+					>
+						{loading ? <CircularProgress size={24} /> : "Unsubscribe"}
+					</Button>
+				</DialogActions>
+			</Dialog>
+		</Paper>
+	);
+};
+
+export default WebhookManager;

--- a/client/src/components/flow/FlowEditor.tsx
+++ b/client/src/components/flow/FlowEditor.tsx
@@ -275,7 +275,6 @@ const FlowEditorContent: React.FC<FlowEditorProps> = ({ flowId }) => {
 			const newEdge: Edge<CustomEdgeData> = {
 				...params,
 				id: `e_${params.source}_${params.target}_${Date.now()}`,
-				data: { label: "Connection" },
 			};
 			setEdges((eds) => addEdge(newEdge, eds));
 		},

--- a/client/src/components/flow/FlowEditor.tsx
+++ b/client/src/components/flow/FlowEditor.tsx
@@ -72,10 +72,12 @@ const theme = createTheme({
 const nodeTypes = {
 	googleSheets: GoogleSheetsNode,
 	facebookAds: FacebookAdsNode,
+	facebookLeadAds: FacebookAdsNode,
 	aiCall: AICallNode,
 	calendar: CalendarNode,
 	webhook: WebhookNode,
 	condition: ConditionNode,
+	preVerify: ConditionNode,
 	email: EmailNode,
 	sms: SMSNode,
 	config: ConfigNode,
@@ -208,6 +210,8 @@ const FlowEditorContent: React.FC<FlowEditorProps> = ({ flowId }) => {
 				return "Google Sheets";
 			case "facebookAds":
 				return "Facebook Ads";
+			case "facebookLeadAds":
+				return "Facebook Lead Ads";
 			case "aiCall":
 				return "AI Call";
 			case "calendar":
@@ -216,6 +220,8 @@ const FlowEditorContent: React.FC<FlowEditorProps> = ({ flowId }) => {
 				return "Webhook";
 			case "condition":
 				return "Condition";
+			case "preVerify":
+				return "Pre-Verify";
 			case "email":
 				return "Send Email";
 			case "sms":
@@ -225,7 +231,8 @@ const FlowEditorContent: React.FC<FlowEditorProps> = ({ flowId }) => {
 			case "error":
 				return "Error Handler";
 			default:
-				return "Unknown Node";
+				console.warn(`Unknown node type: ${type}`);
+				return type || "Unknown Node";
 		}
 	};
 
@@ -236,6 +243,8 @@ const FlowEditorContent: React.FC<FlowEditorProps> = ({ flowId }) => {
 				return "Import leads from Google Sheets";
 			case "facebookAds":
 				return "Import leads from Facebook Ads";
+			case "facebookLeadAds":
+				return "Import leads from Facebook Lead Ads";
 			case "aiCall":
 				return "Process data with AI";
 			case "calendar":
@@ -244,6 +253,8 @@ const FlowEditorContent: React.FC<FlowEditorProps> = ({ flowId }) => {
 				return "Send data to external system";
 			case "condition":
 				return "Branch based on conditions";
+			case "preVerify":
+				return "Pre-verify leads before processing";
 			case "email":
 				return "Send email notification";
 			case "sms":
@@ -253,7 +264,7 @@ const FlowEditorContent: React.FC<FlowEditorProps> = ({ flowId }) => {
 			case "error":
 				return "Handle errors in the flow";
 			default:
-				return "";
+				return `Node type: ${type}`;
 		}
 	};
 

--- a/client/src/components/flow/FlowToolbar.tsx
+++ b/client/src/components/flow/FlowToolbar.tsx
@@ -1,6 +1,19 @@
-import React from "react";
+import React, { useState } from "react";
 import { useReactFlow } from "@xyflow/react";
-import { Box, Button, ButtonGroup, Divider, Tooltip } from "@mui/material";
+import {
+	Box,
+	Button,
+	ButtonGroup,
+	Divider,
+	Tooltip,
+	Dialog,
+	DialogActions,
+	DialogContent,
+	DialogTitle,
+	TextField,
+	Typography,
+	IconButton,
+} from "@mui/material";
 import { styled } from "@mui/material/styles";
 import {
 	Save,
@@ -11,6 +24,7 @@ import {
 	ZoomIn,
 	ZoomOut,
 	CropFree,
+	Edit,
 } from "@mui/icons-material";
 
 type FlowToolbarProps = {
@@ -19,6 +33,8 @@ type FlowToolbarProps = {
 	onExport: () => void;
 	onClear: () => void;
 	onRun: () => void;
+	flowName?: string;
+	onRename?: (newName: string) => void;
 };
 
 const ToolbarButton = styled(Button)(({ theme }) => ({
@@ -35,82 +51,152 @@ const ToolbarContainer = styled(Box)(({ theme }) => ({
 	overflow: "hidden",
 }));
 
+const FlowNameContainer = styled(Box)(({ theme }) => ({
+	display: "flex",
+	alignItems: "center",
+	padding: theme.spacing(0, 2),
+	marginRight: theme.spacing(1),
+}));
+
 const FlowToolbar: React.FC<FlowToolbarProps> = ({
 	onSave,
 	onLoad,
 	onExport,
 	onClear,
 	onRun,
+	flowName = "Untitled Flow",
+	onRename,
 }) => {
 	const { zoomIn, zoomOut, fitView } = useReactFlow();
+	const [renameDialogOpen, setRenameDialogOpen] = useState(false);
+	const [newName, setNewName] = useState(flowName);
+
+	const handleRenameClick = () => {
+		setNewName(flowName);
+		setRenameDialogOpen(true);
+	};
+
+	const handleRenameClose = () => {
+		setRenameDialogOpen(false);
+	};
+
+	const handleRenameConfirm = () => {
+		if (onRename && newName.trim()) {
+			onRename(newName.trim());
+		}
+		setRenameDialogOpen(false);
+	};
 
 	return (
-		<ToolbarContainer>
-			<ButtonGroup variant="text" color="inherit">
-				<Tooltip title="Save Flow">
-					<ToolbarButton onClick={onSave}>
-						<Save fontSize="small" />
+		<>
+			<ToolbarContainer>
+				{onRename && (
+					<>
+						<FlowNameContainer>
+							<Typography variant="subtitle1" noWrap sx={{ maxWidth: 200 }}>
+								{flowName}
+							</Typography>
+							<Tooltip title="Rename Flow">
+								<IconButton
+									onClick={handleRenameClick}
+									size="small"
+									sx={{ ml: 1 }}
+								>
+									<Edit fontSize="small" />
+								</IconButton>
+							</Tooltip>
+						</FlowNameContainer>
+						<Divider orientation="vertical" flexItem />
+					</>
+				)}
+
+				<ButtonGroup variant="text" color="inherit">
+					<Tooltip title="Save Flow">
+						<ToolbarButton onClick={onSave}>
+							<Save fontSize="small" />
+						</ToolbarButton>
+					</Tooltip>
+
+					<Tooltip title="Load Flow">
+						<ToolbarButton onClick={onLoad}>
+							<Upload fontSize="small" />
+						</ToolbarButton>
+					</Tooltip>
+
+					<Tooltip title="Export Flow">
+						<ToolbarButton onClick={onExport}>
+							<Download fontSize="small" />
+						</ToolbarButton>
+					</Tooltip>
+				</ButtonGroup>
+
+				<Divider orientation="vertical" flexItem />
+
+				<ButtonGroup variant="text" color="inherit">
+					<Tooltip title="Zoom In">
+						<ToolbarButton onClick={() => zoomIn()}>
+							<ZoomIn fontSize="small" />
+						</ToolbarButton>
+					</Tooltip>
+
+					<Tooltip title="Zoom Out">
+						<ToolbarButton onClick={() => zoomOut()}>
+							<ZoomOut fontSize="small" />
+						</ToolbarButton>
+					</Tooltip>
+
+					<Tooltip title="Fit View">
+						<ToolbarButton onClick={() => fitView()}>
+							<CropFree fontSize="small" />
+						</ToolbarButton>
+					</Tooltip>
+				</ButtonGroup>
+
+				<Divider orientation="vertical" flexItem />
+
+				<ButtonGroup variant="text" color="inherit">
+					<Tooltip title="Clear Flow">
+						<ToolbarButton onClick={onClear}>
+							<Delete fontSize="small" />
+						</ToolbarButton>
+					</Tooltip>
+				</ButtonGroup>
+
+				<Divider orientation="vertical" flexItem />
+
+				<Tooltip title="Run Flow">
+					<ToolbarButton
+						onClick={onRun}
+						color="primary"
+						variant="contained"
+						sx={{ borderRadius: 0 }}
+					>
+						<PlayArrow fontSize="small" />
 					</ToolbarButton>
 				</Tooltip>
+			</ToolbarContainer>
 
-				<Tooltip title="Load Flow">
-					<ToolbarButton onClick={onLoad}>
-						<Upload fontSize="small" />
-					</ToolbarButton>
-				</Tooltip>
-
-				<Tooltip title="Export Flow">
-					<ToolbarButton onClick={onExport}>
-						<Download fontSize="small" />
-					</ToolbarButton>
-				</Tooltip>
-			</ButtonGroup>
-
-			<Divider orientation="vertical" flexItem />
-
-			<ButtonGroup variant="text" color="inherit">
-				<Tooltip title="Zoom In">
-					<ToolbarButton onClick={() => zoomIn()}>
-						<ZoomIn fontSize="small" />
-					</ToolbarButton>
-				</Tooltip>
-
-				<Tooltip title="Zoom Out">
-					<ToolbarButton onClick={() => zoomOut()}>
-						<ZoomOut fontSize="small" />
-					</ToolbarButton>
-				</Tooltip>
-
-				<Tooltip title="Fit View">
-					<ToolbarButton onClick={() => fitView()}>
-						<CropFree fontSize="small" />
-					</ToolbarButton>
-				</Tooltip>
-			</ButtonGroup>
-
-			<Divider orientation="vertical" flexItem />
-
-			<ButtonGroup variant="text" color="inherit">
-				<Tooltip title="Clear Flow">
-					<ToolbarButton onClick={onClear}>
-						<Delete fontSize="small" />
-					</ToolbarButton>
-				</Tooltip>
-			</ButtonGroup>
-
-			<Divider orientation="vertical" flexItem />
-
-			<Tooltip title="Run Flow">
-				<ToolbarButton
-					onClick={onRun}
-					color="primary"
-					variant="contained"
-					sx={{ borderRadius: 0 }}
-				>
-					<PlayArrow fontSize="small" />
-				</ToolbarButton>
-			</Tooltip>
-		</ToolbarContainer>
+			<Dialog open={renameDialogOpen} onClose={handleRenameClose}>
+				<DialogTitle>Rename Flow</DialogTitle>
+				<DialogContent>
+					<TextField
+						autoFocus
+						margin="dense"
+						label="Flow Name"
+						type="text"
+						fullWidth
+						value={newName}
+						onChange={(e) => setNewName(e.target.value)}
+					/>
+				</DialogContent>
+				<DialogActions>
+					<Button onClick={handleRenameClose}>Cancel</Button>
+					<Button onClick={handleRenameConfirm} color="primary">
+						Rename
+					</Button>
+				</DialogActions>
+			</Dialog>
+		</>
 	);
 };
 

--- a/client/src/components/flow/PropertiesPanel.tsx
+++ b/client/src/components/flow/PropertiesPanel.tsx
@@ -41,6 +41,9 @@ interface NodeSettings {
 	provider?: string;
 	subject?: string;
 	template?: string;
+	connectionId?: string;
+	pageId?: string;
+	formId?: string;
 	[key: string]: string | number | undefined;
 }
 
@@ -153,28 +156,45 @@ const PropertiesPanel: React.FC<PropertiesPanelProps> = ({
 				);
 
 			case "facebookAds":
+			case "facebookLeadAds":
 				return (
 					<>
-						<TextField
-							fullWidth
-							size="small"
-							label="Ad Account ID"
-							variant="outlined"
-							margin="normal"
-							value={localSettings.adAccountId || ""}
-							onChange={handleTextChange("adAccountId")}
-							placeholder="Enter ad account ID"
-						/>
-						<TextField
-							fullWidth
-							size="small"
-							label="Campaign ID"
-							variant="outlined"
-							margin="normal"
-							value={localSettings.campaignId || ""}
-							onChange={handleTextChange("campaignId")}
-							placeholder="Enter campaign ID"
-						/>
+						<FormControl fullWidth margin="normal" size="small">
+							<InputLabel>Choose Connection</InputLabel>
+							<Select
+								value={localSettings.connectionId || ""}
+								onChange={handleSelectChange("connectionId")}
+								label="Choose Connection"
+							>
+								<MenuItem value="conn1">Facebook Connection 1</MenuItem>
+								<MenuItem value="conn2">Facebook Connection 2</MenuItem>
+								<MenuItem value="conn3">Facebook Connection 3</MenuItem>
+							</Select>
+						</FormControl>
+						<FormControl fullWidth margin="normal" size="small">
+							<InputLabel>Choose Page</InputLabel>
+							<Select
+								value={localSettings.pageId || ""}
+								onChange={handleSelectChange("pageId")}
+								label="Choose Page"
+							>
+								<MenuItem value="page1">Page 1</MenuItem>
+								<MenuItem value="page2">Page 2</MenuItem>
+								<MenuItem value="page3">Page 3</MenuItem>
+							</Select>
+						</FormControl>
+						<FormControl fullWidth margin="normal" size="small">
+							<InputLabel>Choose Form</InputLabel>
+							<Select
+								value={localSettings.formId || ""}
+								onChange={handleSelectChange("formId")}
+								label="Choose Form"
+							>
+								<MenuItem value="form1">Contact Form</MenuItem>
+								<MenuItem value="form2">Lead Generation Form</MenuItem>
+								<MenuItem value="form3">Survey Form</MenuItem>
+							</Select>
+						</FormControl>
 					</>
 				);
 
@@ -428,47 +448,13 @@ const PropertiesPanel: React.FC<PropertiesPanelProps> = ({
 						bgcolor={String(selectedNode.data?.color) || "#94a3b8"}
 					/>
 					<Typography variant="subtitle2">
-						{String(selectedNode.data?.label) || "Unknown Node"}
+						{String(selectedNode.type) || "Unknown Node"}
 					</Typography>
 				</Box>
 				<Typography variant="caption" color="text.secondary">
 					{String(selectedNode.data?.description) || "No description available"}
 				</Typography>
 			</NodeInfoCard>
-
-			<TextField
-				fullWidth
-				size="small"
-				label="Node Name"
-				variant="outlined"
-				margin="normal"
-				value={String(selectedNode.data?.label) || ""}
-				onChange={(e) =>
-					onChange(selectedNode.id, {
-						...selectedNode.data,
-						label: e.target.value,
-					})
-				}
-				placeholder="Enter node name"
-			/>
-
-			<TextField
-				fullWidth
-				size="small"
-				label="Description"
-				variant="outlined"
-				margin="normal"
-				multiline
-				rows={2}
-				value={String(selectedNode.data?.description) || ""}
-				onChange={(e) =>
-					onChange(selectedNode.id, {
-						...selectedNode.data,
-						description: e.target.value,
-					})
-				}
-				placeholder="Enter description"
-			/>
 
 			<Divider sx={{ my: 2 }} />
 

--- a/client/src/components/flow/Sidebar.tsx
+++ b/client/src/components/flow/Sidebar.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import {
 	Box,
 	Typography,
@@ -10,6 +10,7 @@ import {
 	Paper,
 	styled,
 	Button,
+	CircularProgress,
 } from "@mui/material";
 import {
 	TableChart,
@@ -23,7 +24,9 @@ import {
 	Settings,
 	ErrorOutline,
 	ArrowBack,
+	Layers,
 } from "@mui/icons-material";
+import { fetchAllNodeTypes, NodeType } from "@/services/nodetypeServices";
 
 type NodeCategory = {
 	title: string;
@@ -35,6 +38,7 @@ type NodeItem = {
 	label: string;
 	icon: React.ReactNode;
 	color: string;
+	description?: string;
 };
 
 const SidebarContainer = styled(Paper)(({ theme }) => ({
@@ -82,7 +86,130 @@ const SidebarFooter = styled(Box)(({ theme }) => ({
 	borderTop: `1px solid ${theme.palette.divider}`,
 }));
 
-const nodeCategories: NodeCategory[] = [
+// Function to determine the icon for a node type
+const getNodeIcon = (key: string) => {
+	switch (key) {
+		case "googleSheets":
+			return <TableChart fontSize="small" />;
+		case "facebookAds":
+		case "facebookLeadAds":
+			return <Facebook fontSize="small" />;
+		case "aiCall":
+			return <SmartToy fontSize="small" />;
+		case "calendar":
+			return <CalendarMonth fontSize="small" />;
+		case "webhook":
+			return <Webhook fontSize="small" />;
+		case "condition":
+		case "preVerify":
+			return <CallSplit fontSize="small" />;
+		case "email":
+			return <Email fontSize="small" />;
+		case "sms":
+			return <Phone fontSize="small" />;
+		case "config":
+			return <Settings fontSize="small" />;
+		case "error":
+			return <ErrorOutline fontSize="small" />;
+		default:
+			return <Layers fontSize="small" />;
+	}
+};
+
+// Function to determine the color for a node type
+const getNodeColor = (key: string) => {
+	switch (key) {
+		case "googleSheets":
+			return "#0F9D58";
+		case "facebookAds":
+		case "facebookLeadAds":
+			return "#1877f2";
+		case "aiCall":
+			return "#10b981";
+		case "calendar":
+			return "#FF5722";
+		case "webhook":
+			return "#2196F3";
+		case "condition":
+		case "preVerify":
+			return "#f59e0b";
+		case "email":
+			return "#00BCD4";
+		case "sms":
+			return "#8BC34A";
+		case "config":
+			return "#795548";
+		case "error":
+			return "#F44336";
+		default:
+			return "#9E9E9E";
+	}
+};
+
+// Phân loại node vào từng danh mục
+const categorizeNodes = (nodes: NodeType[]): NodeCategory[] => {
+	const dataSourcesCategory: NodeItem[] = [];
+	const processingCategory: NodeItem[] = [];
+	const actionsCategory: NodeItem[] = [];
+	const utilitiesCategory: NodeItem[] = [];
+
+	nodes.forEach((node) => {
+		const nodeKey = node.key || "";
+		const nodeItem: NodeItem = {
+			type: nodeKey,
+			label: node.name,
+			icon: getNodeIcon(nodeKey),
+			color: getNodeColor(nodeKey),
+			description: node.description,
+		};
+
+		// Phân loại node dựa trên key hoặc đặc điểm
+		if (
+			nodeKey.includes("facebook") ||
+			nodeKey.includes("google") ||
+			nodeKey.includes("Sheets")
+		) {
+			dataSourcesCategory.push(nodeItem);
+		} else if (
+			nodeKey.includes("Call") ||
+			nodeKey.includes("Verify") ||
+			nodeKey.includes("webhook") ||
+			nodeKey.includes("condition")
+		) {
+			processingCategory.push(nodeItem);
+		} else if (
+			nodeKey.includes("email") ||
+			nodeKey.includes("sms") ||
+			nodeKey.includes("notification")
+		) {
+			actionsCategory.push(nodeItem);
+		} else {
+			utilitiesCategory.push(nodeItem);
+		}
+	});
+
+	return [
+		{
+			title: "Data Sources",
+			items: dataSourcesCategory,
+		},
+		{
+			title: "Processing",
+			items: processingCategory,
+		},
+		{
+			title: "Actions",
+			items: actionsCategory,
+		},
+		{
+			title: "Utilities",
+			items: utilitiesCategory,
+		},
+	].filter((category) => category.items.length > 0); // Lọc các danh mục không có node
+};
+
+// Dữ liệu mẫu dự phòng khi API gặp lỗi
+const fallbackNodeCategories: NodeCategory[] = [
 	{
 		title: "Data Sources",
 		items: [
@@ -170,6 +297,36 @@ type SidebarProps = {
 };
 
 const Sidebar: React.FC<SidebarProps> = ({ onDragStart }) => {
+	const [nodeCategories, setNodeCategories] = useState<NodeCategory[]>([]);
+	const [loading, setLoading] = useState<boolean>(true);
+	const [error, setError] = useState<boolean>(false);
+
+	useEffect(() => {
+		const loadNodeTypes = async () => {
+			try {
+				setLoading(true);
+				const data = await fetchAllNodeTypes();
+
+				if (data && !data.error && Array.isArray(data)) {
+					const categories = categorizeNodes(data);
+					setNodeCategories(categories);
+				} else {
+					console.error("Failed to fetch node types or invalid data format");
+					setNodeCategories(fallbackNodeCategories);
+					setError(true);
+				}
+			} catch (err) {
+				console.error("Error loading node types:", err);
+				setNodeCategories(fallbackNodeCategories);
+				setError(true);
+			} finally {
+				setLoading(false);
+			}
+		};
+
+		loadNodeTypes();
+	}, []);
+
 	return (
 		<SidebarContainer elevation={2} sx={{ height: "100vh", overflowY: "auto" }}>
 			<Button
@@ -183,37 +340,46 @@ const Sidebar: React.FC<SidebarProps> = ({ onDragStart }) => {
 				Flow Components
 			</Typography>
 
-			{nodeCategories.map((category) => (
-				<Box key={category.title} sx={{ mb: 2 }}>
-					<Typography
-						variant="subtitle2"
-						sx={{ mb: 1, color: "text.secondary" }}
-					>
-						{category.title}
-					</Typography>
-
-					<List disablePadding>
-						{category.items.map((item) => (
-							<NodeItem
-								key={item.type}
-								onDragStart={(event) => onDragStart(event, item.type)}
-								draggable
-								disablePadding
-							>
-								<ListItemIcon sx={{ minWidth: 36 }}>
-									<NodeIconContainer bgcolor={item.color}>
-										{item.icon}
-									</NodeIconContainer>
-								</ListItemIcon>
-								<ListItemText
-									primary={item.label}
-									primaryTypographyProps={{ variant: "body2" }}
-								/>
-							</NodeItem>
-						))}
-					</List>
+			{loading ? (
+				<Box sx={{ display: "flex", justifyContent: "center", p: 4 }}>
+					<CircularProgress size={24} />
 				</Box>
-			))}
+			) : (
+				<>
+					{nodeCategories.map((category) => (
+						<Box key={category.title} sx={{ mb: 2 }}>
+							<Typography
+								variant="subtitle2"
+								sx={{ mb: 1, color: "text.secondary" }}
+							>
+								{category.title}
+							</Typography>
+
+							<List disablePadding>
+								{category.items.map((item) => (
+									<NodeItem
+										key={item.type}
+										onDragStart={(event) => onDragStart(event, item.type)}
+										draggable
+										disablePadding
+										title={item.description || item.label}
+									>
+										<ListItemIcon sx={{ minWidth: 36 }}>
+											<NodeIconContainer bgcolor={item.color}>
+												{item.icon}
+											</NodeIconContainer>
+										</ListItemIcon>
+										<ListItemText
+											primary={item.label}
+											primaryTypographyProps={{ variant: "body2" }}
+										/>
+									</NodeItem>
+								))}
+							</List>
+						</Box>
+					))}
+				</>
+			)}
 
 			<SidebarFooter>
 				<Typography variant="caption" color="text.secondary" paragraph>

--- a/client/src/components/flow/nodes/BaseNode.tsx
+++ b/client/src/components/flow/nodes/BaseNode.tsx
@@ -115,6 +115,8 @@ const getActionName = (type: string): string => {
 	switch (type.toLowerCase()) {
 		case "facebookads":
 			return "Get Hook Ads";
+		case "facebookleadads":
+			return "Get Lead Ads";
 		case "googlesheets":
 			return "Get Lead";
 		case "aicall":
@@ -125,6 +127,8 @@ const getActionName = (type: string): string => {
 			return "HTTP Request";
 		case "condition":
 			return "Branch Logic";
+		case "preverify":
+			return "Pre-Verify";
 		case "email":
 			return "Send Email";
 		case "sms":

--- a/client/src/components/flow/nodes/BaseNode.tsx
+++ b/client/src/components/flow/nodes/BaseNode.tsx
@@ -15,6 +15,7 @@ type BaseNodeProps = {
 		inputs?: number;
 		outputs?: number;
 		color?: string;
+		webhookSubscribed?: boolean;
 	};
 	selected: boolean;
 	id: string;

--- a/client/src/components/flow/nodes/NodeTypes.tsx
+++ b/client/src/components/flow/nodes/NodeTypes.tsx
@@ -1,187 +1,190 @@
-
-import { memo } from 'react';
-import BaseNode from './BaseNode';
-import { 
-  TableChart,
-  Facebook,
-  SmartToy,
-  CalendarMonth,
-  Webhook,
-  CallSplit,
-  Email,
-  Phone,
-  Settings,
-  ErrorOutline
-} from '@mui/icons-material';
+import { memo } from "react";
+import BaseNode from "./BaseNode";
+import {
+	TableChart,
+	Facebook,
+	SmartToy,
+	CalendarMonth,
+	Webhook,
+	CallSplit,
+	Email,
+	Phone,
+	Settings,
+	ErrorOutline,
+} from "@mui/icons-material";
 
 // Lead Input Nodes
 export const GoogleSheetsNode = memo(({ data, selected, id }: any) => {
-  return (
-    <BaseNode
-      data={{
-        ...data,
-        label: 'Google Sheets',
-        icon: <TableChart fontSize="small" />,
-        type: 'Input',
-        subType: 'Sheets',
-        color: '#34A853',
-      }}
-      selected={selected}
-      id={id}
-    />
-  );
+	return (
+		<BaseNode
+			data={{
+				...data,
+				label: "Google Sheets",
+				icon: <TableChart fontSize="small" />,
+				type: "Input",
+				subType: "Sheets",
+				color: "#34A853",
+			}}
+			selected={selected}
+			id={id}
+		/>
+	);
 });
 
 export const FacebookAdsNode = memo(({ data, selected, id }: any) => {
-  return (
-    <BaseNode
-      data={{
-        ...data,
-        label: 'Facebook Ads',
-        icon: <Facebook fontSize="small" />,
-        type: 'Input',
-        subType: 'Ads',
-        color: '#1877F2',
-      }}
-      selected={selected}
-      id={id}
-    />
-  );
+	// Xác định loại Facebook node
+	const nodeType = id.split("_")[0];
+	const isLeadAds = nodeType.toLowerCase() === "facebookleadads";
+
+	return (
+		<BaseNode
+			data={{
+				...data,
+				label: isLeadAds ? "Facebook Lead Ads" : "Facebook Ads",
+				icon: <Facebook fontSize="small" />,
+				type: "Input",
+				subType: isLeadAds ? "LeadAds" : "Ads",
+				color: "#1877F2",
+			}}
+			selected={selected}
+			id={id}
+		/>
+	);
 });
 
 // Processing Nodes
 export const AICallNode = memo(({ data, selected, id }: any) => {
-  return (
-    <BaseNode
-      data={{
-        ...data,
-        label: 'AI Call',
-        icon: <SmartToy fontSize="small" />,
-        type: 'Process',
-        subType: 'AI',
-        color: '#10B981',
-      }}
-      selected={selected}
-      id={id}
-    />
-  );
+	return (
+		<BaseNode
+			data={{
+				...data,
+				label: "AI Call",
+				icon: <SmartToy fontSize="small" />,
+				type: "Process",
+				subType: "AI",
+				color: "#10B981",
+			}}
+			selected={selected}
+			id={id}
+		/>
+	);
 });
 
 export const CalendarNode = memo(({ data, selected, id }: any) => {
-  return (
-    <BaseNode
-      data={{
-        ...data,
-        label: 'Google Calendar',
-        icon: <CalendarMonth fontSize="small" />,
-        type: 'Process',
-        subType: 'Calendar',
-        color: '#4285F4',
-      }}
-      selected={selected}
-      id={id}
-    />
-  );
+	return (
+		<BaseNode
+			data={{
+				...data,
+				label: "Google Calendar",
+				icon: <CalendarMonth fontSize="small" />,
+				type: "Process",
+				subType: "Calendar",
+				color: "#4285F4",
+			}}
+			selected={selected}
+			id={id}
+		/>
+	);
 });
 
 export const WebhookNode = memo(({ data, selected, id }: any) => {
-  return (
-    <BaseNode
-      data={{
-        ...data,
-        label: 'Webhook',
-        icon: <Webhook fontSize="small" />,
-        type: 'Process',
-        subType: 'API',
-        color: '#8B5CF6',
-      }}
-      selected={selected}
-      id={id}
-    />
-  );
+	return (
+		<BaseNode
+			data={{
+				...data,
+				label: "Webhook",
+				icon: <Webhook fontSize="small" />,
+				type: "Process",
+				subType: "API",
+				color: "#8B5CF6",
+			}}
+			selected={selected}
+			id={id}
+		/>
+	);
 });
 
 export const ConditionNode = memo(({ data, selected, id }: any) => {
-  return (
-    <BaseNode
-      data={{
-        ...data,
-        label: 'Condition',
-        icon: <CallSplit fontSize="small" />,
-        type: 'Logic',
-        subType: 'Condition',
-        color: '#F59E0B',
-        outputs: 2,
-      }}
-      selected={selected}
-      id={id}
-    />
-  );
+	return (
+		<BaseNode
+			data={{
+				...data,
+				label: "Condition",
+				icon: <CallSplit fontSize="small" />,
+				type: "Logic",
+				subType: "Condition",
+				color: "#F59E0B",
+				outputs: 2,
+			}}
+			selected={selected}
+			id={id}
+		/>
+	);
 });
 
 // Action Nodes
 export const EmailNode = memo(({ data, selected, id }: any) => {
-  return (
-    <BaseNode
-      data={{
-        ...data,
-        label: 'Send Email',
-        icon: <Email fontSize="small" />,
-        type: 'Action',
-        subType: 'Email',
-        color: '#EC4899',
-      }}
-      selected={selected}
-      id={id}
-    />
-  );
+	return (
+		<BaseNode
+			data={{
+				...data,
+				label: "Send Email",
+				icon: <Email fontSize="small" />,
+				type: "Action",
+				subType: "Email",
+				color: "#EC4899",
+			}}
+			selected={selected}
+			id={id}
+		/>
+	);
 });
 
 export const SMSNode = memo(({ data, selected, id }: any) => {
-  return (
-    <BaseNode
-      data={{
-        ...data,
-        label: 'Send SMS',
-        icon: <Phone fontSize="small" />,
-        type: 'Action',
-        subType: 'SMS',
-        color: '#6366F1',
-      }}
-      selected={selected}
-      id={id}
-    />
-  );
+	return (
+		<BaseNode
+			data={{
+				...data,
+				label: "Send SMS",
+				icon: <Phone fontSize="small" />,
+				type: "Action",
+				subType: "SMS",
+				color: "#6366F1",
+			}}
+			selected={selected}
+			id={id}
+		/>
+	);
 });
 
 export const ConfigNode = memo(({ data, selected, id }: any) => {
-  return (
-    <BaseNode
-      data={{
-        ...data,
-        label: 'Configuration',
-        icon: <Settings fontSize="small" />,
-        type: 'Settings',
-        color: '#6B7280',
-      }}
-      selected={selected}
-      id={id}
-    />
-  );
+	return (
+		<BaseNode
+			data={{
+				...data,
+				label: "Configuration",
+				icon: <Settings fontSize="small" />,
+				type: "Settings",
+				color: "#6B7280",
+			}}
+			selected={selected}
+			id={id}
+		/>
+	);
 });
 
 export const ErrorNode = memo(({ data, selected, id }: any) => {
-  return (
-    <BaseNode
-      data={{
-        ...data,
-        label: 'Error Handler',
-        icon: <ErrorOutline fontSize="small" />,
-        type: 'Error',
-        color: '#EF4444',
-      }}
-      selected={selected}
-      id={id}
-    />
-  );
+	return (
+		<BaseNode
+			data={{
+				...data,
+				label: "Error Handler",
+				icon: <ErrorOutline fontSize="small" />,
+				type: "Error",
+				color: "#EF4444",
+			}}
+			selected={selected}
+			id={id}
+		/>
+	);
 });

--- a/client/src/components/layouts/DefaultLayout.tsx
+++ b/client/src/components/layouts/DefaultLayout.tsx
@@ -1,0 +1,35 @@
+import React, { ReactNode } from "react";
+import { Box, AppBar, Toolbar, Typography, Container } from "@mui/material";
+
+interface DefaultLayoutProps {
+	children: ReactNode;
+}
+
+export const DefaultLayout: React.FC<DefaultLayoutProps> = ({ children }) => {
+	return (
+		<Box sx={{ display: "flex", flexDirection: "column", minHeight: "100vh" }}>
+			<AppBar position="static">
+				<Toolbar>
+					<Typography variant="h6" component="div" sx={{ flexGrow: 1 }}>
+						Facebook Lead Ads Manager
+					</Typography>
+				</Toolbar>
+			</AppBar>
+
+			<Box component="main" sx={{ flexGrow: 1 }}>
+				{children}
+			</Box>
+
+			<Box
+				component="footer"
+				sx={{ py: 3, bgcolor: "background.paper", mt: "auto" }}
+			>
+				<Container maxWidth="lg">
+					<Typography variant="body2" color="text.secondary" align="center">
+						© {new Date().getFullYear()} Facebook Lead Ads Manager
+					</Typography>
+				</Container>
+			</Box>
+		</Box>
+	);
+};

--- a/client/src/pages/facebook/WebhookManager.tsx
+++ b/client/src/pages/facebook/WebhookManager.tsx
@@ -1,0 +1,54 @@
+import React from "react";
+import {
+	Box,
+	Typography,
+	Container,
+	Breadcrumbs,
+	Link,
+	Paper,
+} from "@mui/material";
+import { NavigateNext as NavigateNextIcon } from "@mui/icons-material";
+import PageWebhookList from "@/components/facebook/PageWebhookList";
+import { DefaultLayout } from "@/components/layouts/DefaultLayout";
+
+const FacebookWebhookManager: React.FC = () => {
+	return (
+		<DefaultLayout>
+			<Container maxWidth="lg" sx={{ mt: 4, mb: 4 }}>
+				{/* Breadcrumbs Navigation */}
+				<Breadcrumbs
+					separator={<NavigateNextIcon fontSize="small" />}
+					aria-label="breadcrumb"
+					sx={{ mb: 3 }}
+				>
+					<Link color="inherit" href="/dashboard">
+						Dashboard
+					</Link>
+					<Link color="inherit" href="/facebook">
+						Facebook
+					</Link>
+					<Typography color="text.primary">Webhook Manager</Typography>
+				</Breadcrumbs>
+
+				{/* Page Header */}
+				<Paper sx={{ p: 3, mb: 4 }}>
+					<Typography variant="h4" component="h1" gutterBottom>
+						Facebook Webhook Management
+					</Typography>
+					<Typography variant="body1" color="text.secondary">
+						Manage webhook subscriptions for your Facebook pages. When
+						subscribed, your application will receive lead data in real-time
+						when new leads are generated from Facebook Lead Ads.
+					</Typography>
+				</Paper>
+
+				{/* Page Content */}
+				<Box>
+					<PageWebhookList />
+				</Box>
+			</Container>
+		</DefaultLayout>
+	);
+};
+
+export default FacebookWebhookManager;

--- a/client/src/services/facebookServices.tsx
+++ b/client/src/services/facebookServices.tsx
@@ -1,0 +1,218 @@
+import { useEffect, useState } from "react";
+import axios from "@/utils/axios";
+import { toast } from "react-toastify";
+
+interface FacebookPage {
+	id: string;
+	name: string;
+	access_token: string;
+	forms?: Array<{
+		id: string;
+		name: string;
+		[key: string]: any;
+	}>;
+	[key: string]: any;
+}
+
+interface FacebookConnection {
+	provider: string;
+	profile: {
+		id: string;
+		name: string;
+		accessToken: string;
+		[key: string]: any;
+	};
+	pages: FacebookPage[];
+	[key: string]: any;
+}
+
+interface UserWithConnections {
+	_id: string;
+	adsConnection: FacebookConnection[];
+	[key: string]: any;
+}
+
+// Update Facebook connection
+export const updateFacebookConnection = async (profile: any) => {
+	try {
+		const response = await axios.post("/facebook/connection", { profile });
+		toast.success("Facebook connection has been updated");
+		return response.data;
+	} catch (error: any) {
+		console.error("Error updating Facebook connection:", error);
+		toast.error(
+			error?.response?.data?.message || "Error updating Facebook connection"
+		);
+		return { error };
+	}
+};
+
+// Get user's Facebook pages
+export const getUserFacebookPages = async (profileId: string) => {
+	try {
+		const response = await axios.get(`/facebook/pages/${profileId}`);
+		return response.data;
+	} catch (error: any) {
+		console.error("Error getting pages list:", error);
+		toast.error(
+			error?.response?.data?.message || "Error getting Facebook pages"
+		);
+		return { error };
+	}
+};
+
+// Get forms for a Facebook page
+export const getFacebookPageForms = async (pageId: string) => {
+	try {
+		const response = await axios.get(`/facebook/forms/${pageId}`);
+		return response.data;
+	} catch (error: any) {
+		console.error("Error getting forms list:", error);
+		toast.error(
+			error?.response?.data?.message || "Error getting Facebook forms"
+		);
+		return { error };
+	}
+};
+
+// Subscribe a page to webhook
+export const subscribePageToWebhook = async (pageId: string) => {
+	try {
+		const response = await axios.post(`/facebook/subscribe/${pageId}`);
+		toast.success("Successfully subscribed page to webhook");
+		return response.data;
+	} catch (error: any) {
+		console.error("Error subscribing to webhook:", error);
+		toast.error(
+			error?.response?.data?.message || "Error subscribing to webhook"
+		);
+		return { error };
+	}
+};
+
+// Unsubscribe a page from webhook
+export const unsubscribePageFromWebhook = async (
+	pageId: string,
+	appId: string
+) => {
+	try {
+		const response = await axios.delete(`/facebook/subscribe/${pageId}`, {
+			data: { appId },
+		});
+		toast.success("Successfully unsubscribed page from webhook");
+		return response.data;
+	} catch (error: any) {
+		console.error("Error unsubscribing from webhook:", error);
+		toast.error(
+			error?.response?.data?.message || "Error unsubscribing from webhook"
+		);
+		return { error };
+	}
+};
+
+// Hook to get user's Facebook connections
+export const useFacebookConnections = () => {
+	const [connections, setConnections] = useState<FacebookConnection[]>([]);
+	const [loading, setLoading] = useState<boolean>(true);
+	const [error, setError] = useState<string | null>(null);
+
+	useEffect(() => {
+		const fetchConnections = async () => {
+			try {
+				setLoading(true);
+				const response = await axios.get("/user/me");
+				const user = response.data as UserWithConnections;
+				const facebookConnections =
+					user.adsConnection?.filter((conn) => conn.provider === "facebook") ||
+					[];
+				setConnections(facebookConnections);
+				setLoading(false);
+			} catch (err: any) {
+				console.error("Error fetching Facebook connections:", err);
+				setError(
+					err?.response?.data?.message || "Error fetching Facebook connections"
+				);
+				setLoading(false);
+			}
+		};
+
+		fetchConnections();
+	}, []);
+
+	return { connections, loading, error };
+};
+
+// Hook to get pages for a Facebook connection
+export const useFacebookPages = (profileId: string | null) => {
+	const [pages, setPages] = useState<FacebookPage[]>([]);
+	const [loading, setLoading] = useState<boolean>(false);
+	const [error, setError] = useState<string | null>(null);
+
+	useEffect(() => {
+		if (!profileId) return;
+
+		const fetchPages = async () => {
+			try {
+				setLoading(true);
+				const response = await getUserFacebookPages(profileId);
+				if (response && !response.error) {
+					const userPages =
+						response.adsConnection?.find(
+							(conn: any) => conn.profile.id === profileId
+						)?.pages || [];
+					setPages(userPages);
+				} else {
+					setError("Unable to fetch page list");
+				}
+				setLoading(false);
+			} catch (err: any) {
+				console.error("Error fetching Facebook pages:", err);
+				setError(
+					err?.response?.data?.message || "Error fetching Facebook pages"
+				);
+				setLoading(false);
+			}
+		};
+
+		fetchPages();
+	}, [profileId]);
+
+	return { pages, loading, error };
+};
+
+// Hook to get forms for a Facebook page
+export const useFacebookForms = (pageId: string | null) => {
+	const [forms, setForms] = useState<any[]>([]);
+	const [loading, setLoading] = useState<boolean>(false);
+	const [error, setError] = useState<string | null>(null);
+
+	useEffect(() => {
+		if (!pageId) return;
+
+		const fetchForms = async () => {
+			try {
+				setLoading(true);
+				const response = await getFacebookPageForms(pageId);
+				if (response && !response.error) {
+					const page = response.adsConnection?.[0]?.pages?.find(
+						(p: any) => p.id === pageId
+					);
+					setForms(page?.forms || []);
+				} else {
+					setError("Unable to fetch form list");
+				}
+				setLoading(false);
+			} catch (err: any) {
+				console.error("Error fetching Facebook forms:", err);
+				setError(
+					err?.response?.data?.message || "Error fetching Facebook forms"
+				);
+				setLoading(false);
+			}
+		};
+
+		fetchForms();
+	}, [pageId]);
+
+	return { forms, loading, error };
+};

--- a/client/src/services/nodetypeServices.tsx
+++ b/client/src/services/nodetypeServices.tsx
@@ -1,0 +1,104 @@
+import { useEffect, useState } from "react";
+import axios from "@/utils/axios";
+import { toast } from "react-toastify";
+
+// -----------------------------------nodeTypes-----------------------------------
+
+export const fetchAllNodeTypes = async () => {
+	try {
+		const response = await axios.get("/nodeType");
+		return response.data;
+	} catch (error: any) {
+		console.log(error);
+		toast.error("Failed to fetch node types!");
+		return { error };
+	}
+};
+
+export const getNodeTypeById = async (nodeTypeId: string) => {
+	try {
+		const response = await axios.get(`/nodeType/${nodeTypeId}`);
+		return response.data;
+	} catch (error: any) {
+		console.log(error);
+		toast.error("Failed to fetch node type details!");
+		return { error };
+	}
+};
+
+export const createNodeType = async (nodeTypeData: any) => {
+	try {
+		const response = await axios.post("/nodeType", nodeTypeData);
+		toast.success("Successfully created node type!");
+		return response.data;
+	} catch (error: any) {
+		console.log(error);
+		toast.error(
+			`${error?.response?.data?.message || "Failed to create node type!"}`
+		);
+		return { error };
+	}
+};
+
+export const updateNodeType = async (nodeTypeId: string, nodeTypeData: any) => {
+	try {
+		const response = await axios.put(`/nodeType/${nodeTypeId}`, nodeTypeData);
+		toast.success("Successfully updated node type!");
+		return response.data;
+	} catch (error: any) {
+		console.log(error);
+		toast.error(
+			`${error?.response?.data?.message || "Failed to update node type!"}`
+		);
+		return { error };
+	}
+};
+
+export const deleteNodeType = async (nodeTypeId: string) => {
+	try {
+		const response = await axios.delete(`/nodeType/${nodeTypeId}`);
+		toast.success("Successfully deleted node type!");
+		return response.data;
+	} catch (error: any) {
+		console.log(error);
+		toast.error(
+			`${error?.response?.data?.message || "Failed to delete node type!"}`
+		);
+		return { error };
+	}
+};
+
+export const resetNodeTypeExchange = async () => {
+	try {
+		const response = await axios.post("/nodeType/resetExchange");
+		toast.success("Successfully reset node type exchange!");
+		return response.data;
+	} catch (error: any) {
+		console.log(error);
+		toast.error(
+			`${
+				error?.response?.data?.message || "Failed to reset node type exchange!"
+			}`
+		);
+		return { error };
+	}
+};
+
+// Types
+export interface NodeTypeField {
+	name: string;
+	dataType: "String" | "Number" | "Boolean" | "Date" | "Array" | "Object";
+	advanceData?: any;
+	isRequired: boolean;
+	description?: string;
+	_id?: string;
+}
+
+export interface NodeType {
+	_id?: string;
+	name: string;
+	key?: string;
+	img?: string;
+	description?: string;
+	fields: NodeTypeField[];
+}


### PR DESCRIPTION
## ✅ Merge Request Title:
**FE Feature: Implement FlowEditing Page with FlowAPI & Facebook API Integration**

---

## 📌 Summary
This MR implements backend integrations for the `FlowEditing` page, connecting it with **FlowAPI**, **NodetypeAPI**, and **Facebook API**. The goal is to enable data retrieval, updates, and external resource linking necessary for flow editing functionality.

---

## ✅ Implemented Features

### Flow API
- Fetch flow data via `getFlowById`
- Update existing flow
- Rename a flow

### Nodetype API
- Fetch all available node types for flow construction

### Facebook API
- Retrieve connected Facebook Pages
- Retrieve available lead forms for selected pages

---

## ⚠️ Known Issues / Bugs (To be addressed later)
- [ ] Create new flow (path 'name' required)
- [ ] Page Subscribe/Unsubscribe actions are not fully functional

